### PR TITLE
fix: Fixed nosel not working with displayif

### DIFF
--- a/dssmenucore.lua
+++ b/dssmenucore.lua
@@ -1167,6 +1167,14 @@ return function(DSSModName, DSSCoreVersion, MenuProvider)
 
             allnosel = true
             for i, button in ipairs(buttons) do
+                if button.originalnosel == nil then
+                    if button.nosel == nil then
+                        button.originalnosel = false
+                    else
+                        button.originalnosel = button.nosel
+                    end
+                end
+
                 button.selected = false
                 if button.generate and itemswitched then
                     button.generate(button, item, tbl)
@@ -1181,7 +1189,7 @@ return function(DSSModName, DSSCoreVersion, MenuProvider)
                         button.nosel = true
                         button.forcenodisplay = true
                     elseif button.forcenodisplay then
-                        button.nosel = nil
+                        button.nosel = button.originalnosel
                         button.forcenodisplay = nil
                     end
                 end


### PR DESCRIPTION
A very simple fix since the nosel tag got reset when the displayif condition changed from false to true.